### PR TITLE
chore: upgrade react to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "dependencies": {
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/react-editor": "^3.2.3",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
-    "@types/react": "^19.1.10",
-    "@types/react-dom": "^19.1.7",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.33.0",


### PR DESCRIPTION
## Summary
- upgrade React and React DOM to v18
- align @types packages with React 18

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact-dom)*
- `npm run build` *(fails: Rollup failed to resolve import "react-dom/client")*

------
https://chatgpt.com/codex/tasks/task_e_68b7a1e5806c832788e974bbfbf1475d